### PR TITLE
Add ClientFactory for generating test clients

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -16,6 +16,74 @@ namespace App\Models{
  * 
  *
  * @property int $id
+ * @property string $last_name Фамилия
+ * @property string $first_name Имя
+ * @property string|null $middle_name Отчество
+ * @property string|null $company Компания
+ * @property string $email E-mail клиента
+ * @property string|null $phone Телефон
+ * @property string|null $address Адрес
+ * @property string|null $latitude Широта
+ * @property string|null $longitude Долгота
+ * @property int $status_id Статус клиента
+ * @property int|null $assigned_user_id Ответственный менеджер
+ * @property int $created_by_user_id Кто создал запись
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\User|null $assignedUser
+ * @property-read \App\Models\User $creator
+ * @property-read \App\Models\Status $status
+ * @method static \Database\Factories\ClientFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereAddress($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereAssignedUserId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereCompany($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereCreatedByUserId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereEmail($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereFirstName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereLastName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereLatitude($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereLongitude($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereMiddleName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client wherePhone($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereStatusId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Client whereUpdatedAt($value)
+ */
+	class Client extends \Eloquent {}
+}
+
+namespace App\Models{
+/**
+ * 
+ *
+ * @property int $id
+ * @property string $name Название статуса, например: новый, в работе, закрыт
+ * @property string|null $description Подробное описание статуса
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Client> $clients
+ * @property-read int|null $clients_count
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Status newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Status newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Status query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Status whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Status whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Status whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Status whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|Status whereUpdatedAt($value)
+ */
+	class Status extends \Eloquent {}
+}
+
+namespace App\Models{
+/**
+ * 
+ *
+ * @property int $id
  * @property string $name
  * @property string $email
  * @property \Illuminate\Support\Carbon|null $email_verified_at

--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class Client extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'last_name',
+        'first_name',
+        'middle_name',
+        'company',
+        'email',
+        'phone',
+        'address',
+        'latitude',
+        'longitude',
+        'status_id',
+        'assigned_user_id',
+        'created_by_user_id',
+    ];
+
+    /**
+     * Статус клиента
+     */
+    public function status(): BelongsTo
+    {
+        return $this->belongsTo(Status::class);
+    }
+
+    /**
+     * Ответственный менеджер
+     */
+    public function assignedUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_user_id');
+    }
+
+    /**
+     * Автор записи
+     */
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+}

--- a/app/Models/Status.php
+++ b/app/Models/Status.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Status extends Model
+{
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+
+    /**
+     * Клиенты с этим статусом
+     */
+    public function clients(): HasMany
+    {
+        return $this->hasMany(Client::class);
+    }
+}

--- a/database/factories/ClientFactory.php
+++ b/database/factories/ClientFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Client;
+use App\Models\Status;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ClientFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Client::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        $statusId    = Status::inRandomOrder()->value('id') ?? Status::factory()->create()->id;
+        $createdById = User::inRandomOrder()->value('id') ?? User::factory()->create()->id;
+        $assignedId  = User::inRandomOrder()->value('id') ?? User::factory()->create()->id;
+
+        return [
+            'first_name'         => $this->faker->firstName(),
+            'last_name'          => $this->faker->lastName(),
+            'middle_name'        => $this->faker->optional()->firstName(),
+            'company'            => $this->faker->optional()->company(),
+            'email'              => $this->faker->unique()->safeEmail(),
+            'phone'              => $this->faker->optional()->phoneNumber(),
+            'address'            => $this->faker->optional()->address(),
+            'latitude'           => $this->faker->optional()->latitude(),
+            'longitude'          => $this->faker->optional()->longitude(),
+
+            'status_id'          => $statusId,
+            'created_by_user_id' => $createdById,
+            'assigned_user_id'   => $assignedId,
+        ];
+    }
+}

--- a/database/migrations/2025_06_30_121128_create_statuses_table.php
+++ b/database/migrations/2025_06_30_121128_create_statuses_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('statuses', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 50)->unique()->comment('Название статуса, например: новый, в работе, закрыт');
+            $table->text('description')->nullable()->comment('Подробное описание статуса');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('statuses');
+    }
+};

--- a/database/migrations/2025_06_30_121259_create_clients_table.php
+++ b/database/migrations/2025_06_30_121259_create_clients_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateClientsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('clients', function (Blueprint $table) {
+            $table->id();
+            $table->string('last_name', 100)->comment('Фамилия');
+            $table->string('first_name', 100)->comment('Имя');
+            $table->string('middle_name', 100)->nullable()->comment('Отчество');
+            $table->string('company', 150)->nullable()->comment('Компания');
+            $table->string('email', 150)->unique()->comment('E-mail клиента');
+            $table->string('phone', 50)->nullable()->comment('Телефон');
+            $table->text('address')->nullable()->comment('Адрес');
+            $table->decimal('latitude', 10, 7)->nullable()->comment('Широта');
+            $table->decimal('longitude', 10, 7)->nullable()->comment('Долгота');
+
+            // Внешние ключи
+            $table->unsignedBigInteger('status_id')->comment('Статус клиента');
+            $table->unsignedBigInteger('assigned_user_id')->nullable()->comment('Ответственный менеджер');
+            $table->unsignedBigInteger('created_by_user_id')->comment('Кто создал запись');
+
+            $table->timestamps();
+
+            // Связи
+            $table->foreign('status_id')
+                  ->references('id')
+                  ->on('statuses')
+                  ->onDelete('restrict');
+
+            $table->foreign('assigned_user_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('set null');
+
+            $table->foreign('created_by_user_id')
+                  ->references('id')
+                  ->on('users')
+                  ->onDelete('cascade');
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('clients');
+    }
+}

--- a/database/seeders/ClientSeeder.php
+++ b/database/seeders/ClientSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Client;
+use App\Models\Status;
+use App\Models\User;
+use Faker\Factory as Faker;
+
+class ClientSeeder extends Seeder
+{
+    public function run()
+    {
+        $faker = Faker::create();
+
+        $statusIds = Status::pluck('id')->all();
+        $creatorId = User::first()->id ?? 1;
+
+        Client::factory()
+            ->count(50)
+            ->state(function () use ($statusIds, $creatorId, $faker) {
+                return [
+                    'status_id'          => $faker->randomElement($statusIds),
+                    'created_by_user_id' => $creatorId,
+                    'assigned_user_id'   => User::inRandomOrder()->first()->id ?? $creatorId,
+                ];
+            })
+            ->create();
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,6 +17,8 @@ class DatabaseSeeder extends Seeder
         $this->call([
             RolesAndPermissionsSeeder::class,
             UserSeeder::class,
+            StatusSeeder::class,
+            ClientSeeder::class,
         ]);
     }
 }

--- a/database/seeders/StatusSeeder.php
+++ b/database/seeders/StatusSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use App\Models\Status;
+
+class StatusSeeder extends Seeder
+{
+    public function run()
+    {
+        $statuses = [
+            ['name' => 'Новый',      'description' => 'Только что добавленный клиент'],
+            ['name' => 'В работе',   'description' => 'Менеджер ведёт коммуникацию'],
+            ['name' => 'Закрыт',     'description' => 'Сделка завершена'],
+            ['name' => 'Отложен',    'description' => 'Заявка отложена'],
+        ];
+
+        foreach ($statuses as $data) {
+            Status::firstOrCreate(['name' => $data['name']], $data);
+        }
+    }
+}


### PR DESCRIPTION
Introduce ClientFactory to streamline creation of test Client records.

- Define default state for Client with realistic faker data:
  - first_name, last_name, middle_name
  - company, email, phone, address
  - latitude, longitude
- Associate each Client with a random or newly created Status and User:
  - status_id
  - created_by_user_id
  - assigned_user_id

This factory enables easy seeding and testing of Client-related functionality.
